### PR TITLE
Support fsspec storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cyvcf2
 dask[array]
+fsspec
 numba
 numpy
 xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ python_requires = >=3.7
 install_requires =
     cyvcf2
     dask
+    fsspec
     numpy
     xarray
     setuptools >= 41.2  # For pkg_resources
@@ -52,7 +53,7 @@ ignore =
 [isort]
 default_section = THIRDPARTY
 known_first_party = sgkit
-known_third_party = cyvcf2,dask,numpy,pytest,setuptools,xarray
+known_third_party = cyvcf2,dask,fsspec,numpy,pytest,setuptools,xarray
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
@@ -62,6 +63,8 @@ line_length = 88
 [mypy-cyvcf2.*]
 ignore_missing_imports = True
 [mypy-dask.*]
+ignore_missing_imports = True
+[mypy-fsspec.*]
 ignore_missing_imports = True
 [mypy-numpy.*]
 ignore_missing_imports = True

--- a/sgkit_vcf/csi.py
+++ b/sgkit_vcf/csi.py
@@ -3,14 +3,20 @@
 The implementation follows the [CSI index file format](http://samtools.github.io/hts-specs/CSIv1.pdf).
 
 """
-import gzip
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 
 from sgkit.typing import PathType
-from sgkit_vcf.utils import get_file_offset, read_bytes_as_tuple, read_bytes_as_value
+from sgkit_vcf.utils import (
+    get_file_offset,
+    open_gzip,
+    read_bytes_as_tuple,
+    read_bytes_as_value,
+)
+
+CSI_EXTENSION = ".csi"
 
 
 @dataclass
@@ -83,7 +89,9 @@ def get_first_locus_in_bin(csi: CSIIndex, bin: int) -> int:
     return (bin - first_bin_on_level) * (max_span // level_size) + 1
 
 
-def read_csi(file: PathType) -> CSIIndex:
+def read_csi(
+    file: PathType, storage_options: Optional[Dict[str, str]] = None
+) -> CSIIndex:
     """Parse a CSI file into a `CSIIndex` object.
 
     Parameters
@@ -101,7 +109,7 @@ def read_csi(file: PathType) -> CSIIndex:
     ValueError
         If the file is not a CSI file.
     """
-    with gzip.open(file) as f:
+    with open_gzip(file, storage_options=storage_options) as f:
         magic = read_bytes_as_value(f, "4s")
         if magic != b"CSI\x01":
             raise ValueError("File not in CSI format.")

--- a/sgkit_vcf/tbi.py
+++ b/sgkit_vcf/tbi.py
@@ -3,15 +3,20 @@
 The implementation follows the [Tabix index file format](https://samtools.github.io/hts-specs/tabix.pdf).
 
 """
-import gzip
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
 
 from sgkit.typing import PathType
-from sgkit_vcf.utils import get_file_offset, read_bytes_as_tuple, read_bytes_as_value
+from sgkit_vcf.utils import (
+    get_file_offset,
+    open_gzip,
+    read_bytes_as_tuple,
+    read_bytes_as_value,
+)
 
+TABIX_EXTENSION = ".tbi"
 TABIX_LINEAR_INDEX_INTERVAL_SIZE = 1 << 14  # 16kb interval size
 
 
@@ -73,7 +78,9 @@ class TabixIndex:
         return file_offsets, contig_indexes, positions
 
 
-def read_tabix(file: PathType) -> TabixIndex:
+def read_tabix(
+    file: PathType, storage_options: Optional[Dict[str, str]] = None
+) -> TabixIndex:
     """Parse a tabix file into a `TabixIndex` object.
 
     Parameters
@@ -91,7 +98,7 @@ def read_tabix(file: PathType) -> TabixIndex:
     ValueError
         If the file is not a tabix file.
     """
-    with gzip.open(file) as f:
+    with open_gzip(file, storage_options=storage_options) as f:
         magic = read_bytes_as_value(f, "4s")
         if magic != b"TBI\x01":
             raise ValueError("File not in Tabix format.")

--- a/sgkit_vcf/tests/test_csi.py
+++ b/sgkit_vcf/tests/test_csi.py
@@ -2,6 +2,7 @@ import pytest
 from cyvcf2 import VCF
 
 from sgkit_vcf.csi import read_csi
+from sgkit_vcf.tests.utils import path_for_test
 from sgkit_vcf.vcf_partition import get_csi_path
 from sgkit_vcf.vcf_reader import count_variants
 
@@ -9,9 +10,12 @@ from sgkit_vcf.vcf_reader import count_variants
 @pytest.mark.parametrize(
     "vcf_file", ["CEUTrio.20.21.gatk3.4.csi.g.vcf.bgz",],
 )
-def test_record_counts_csi(shared_datadir, vcf_file):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_record_counts_csi(shared_datadir, vcf_file, is_path):
     # Check record counts in csi with actual count of VCF
-    vcf_path = shared_datadir / vcf_file
+    vcf_path = path_for_test(shared_datadir, vcf_file, is_path)
     csi_path = get_csi_path(vcf_path)
     csi = read_csi(csi_path)
 
@@ -22,6 +26,9 @@ def test_record_counts_csi(shared_datadir, vcf_file):
 @pytest.mark.parametrize(
     "file", ["CEUTrio.20.21.gatk3.4.g.vcf.bgz", "CEUTrio.20.21.gatk3.4.g.vcf.bgz.tbi"],
 )
-def test_read_csi__invalid_csi(shared_datadir, file):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_read_csi__invalid_csi(shared_datadir, file, is_path):
     with pytest.raises(ValueError, match=r"File not in CSI format."):
-        read_csi(shared_datadir / file)
+        read_csi(path_for_test(shared_datadir, file, is_path))

--- a/sgkit_vcf/tests/test_tbi.py
+++ b/sgkit_vcf/tests/test_tbi.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sgkit_vcf.tbi import read_tabix
+from sgkit_vcf.tests.utils import path_for_test
 from sgkit_vcf.vcf_partition import get_tabix_path
 from sgkit_vcf.vcf_reader import count_variants
 
@@ -8,9 +9,12 @@ from sgkit_vcf.vcf_reader import count_variants
 @pytest.mark.parametrize(
     "vcf_file", ["CEUTrio.20.21.gatk3.4.g.vcf.bgz",],
 )
-def test_record_counts_tbi(shared_datadir, vcf_file):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_record_counts_tbi(shared_datadir, vcf_file, is_path):
     # Check record counts in tabix with actual count of VCF
-    vcf_path = shared_datadir / vcf_file
+    vcf_path = path_for_test(shared_datadir, vcf_file, is_path)
     tabix_path = get_tabix_path(vcf_path)
     tabix = read_tabix(tabix_path)
 
@@ -22,6 +26,9 @@ def test_record_counts_tbi(shared_datadir, vcf_file):
     "file",
     ["CEUTrio.20.21.gatk3.4.g.vcf.bgz", "CEUTrio.20.21.gatk3.4.csi.g.vcf.bgz.csi"],
 )
-def test_read_tabix__invalid_tbi(shared_datadir, file):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_read_tabix__invalid_tbi(shared_datadir, file, is_path):
     with pytest.raises(ValueError, match=r"File not in Tabix format."):
-        read_tabix(shared_datadir / file)
+        read_tabix(path_for_test(shared_datadir, file, is_path))

--- a/sgkit_vcf/tests/test_vcf_partition.py
+++ b/sgkit_vcf/tests/test_vcf_partition.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sgkit_vcf.tests.utils import path_for_test
 from sgkit_vcf.vcf_partition import partition_into_regions
 from sgkit_vcf.vcf_reader import count_variants
 
@@ -12,8 +13,11 @@ from sgkit_vcf.vcf_reader import count_variants
         "NA12878.prod.chr20snippet.g.vcf.gz",
     ],
 )
-def test_partition_into_regions__num_parts(shared_datadir, vcf_file):
-    vcf_path = shared_datadir / vcf_file
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_partition_into_regions__num_parts(shared_datadir, vcf_file, is_path):
+    vcf_path = path_for_test(shared_datadir, vcf_file, is_path)
 
     regions = partition_into_regions(vcf_path, num_parts=4)
 
@@ -24,8 +28,11 @@ def test_partition_into_regions__num_parts(shared_datadir, vcf_file):
     assert sum(part_variant_counts) == total_variants
 
 
-def test_partition_into_regions__num_parts_large(shared_datadir):
-    vcf_path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_partition_into_regions__num_parts_large(shared_datadir, is_path):
+    vcf_path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
 
     regions = partition_into_regions(vcf_path, num_parts=100)
     assert regions is not None
@@ -37,8 +44,11 @@ def test_partition_into_regions__num_parts_large(shared_datadir):
     assert sum(part_variant_counts) == total_variants
 
 
-def test_partition_into_regions__target_part_size(shared_datadir):
-    vcf_path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_partition_into_regions__target_part_size(shared_datadir, is_path):
+    vcf_path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
 
     regions = partition_into_regions(vcf_path, target_part_size=100_000)
     assert regions is not None
@@ -50,8 +60,11 @@ def test_partition_into_regions__target_part_size(shared_datadir):
     assert sum(part_variant_counts) == total_variants
 
 
-def test_partition_into_regions__invalid_arguments(shared_datadir):
-    vcf_path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_partition_into_regions__invalid_arguments(shared_datadir, is_path):
+    vcf_path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
 
     with pytest.raises(
         ValueError, match=r"One of num_parts or target_part_size must be specified"
@@ -70,16 +83,26 @@ def test_partition_into_regions__invalid_arguments(shared_datadir):
         partition_into_regions(vcf_path, target_part_size=0)
 
 
-def test_partition_into_regions__one_part(shared_datadir):
-    vcf_path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_partition_into_regions__one_part(shared_datadir, is_path):
+    vcf_path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
     assert partition_into_regions(vcf_path, num_parts=1) is None
 
 
-def test_partition_into_regions__missing_index(shared_datadir):
-    vcf_path = shared_datadir / "CEUTrio.20.21.gatk3.4.noindex.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_partition_into_regions__missing_index(shared_datadir, is_path):
+    vcf_path = path_for_test(
+        shared_datadir, "CEUTrio.20.21.gatk3.4.noindex.g.vcf.bgz", is_path
+    )
     with pytest.raises(ValueError, match=r"Cannot find .tbi or .csi file."):
         partition_into_regions(vcf_path, num_parts=2)
 
-    bogus_index_path = shared_datadir / "CEUTrio.20.21.gatk3.4.noindex.g.vcf.bgz.index"
+    bogus_index_path = path_for_test(
+        shared_datadir, "CEUTrio.20.21.gatk3.4.noindex.g.vcf.bgz.index", is_path
+    )
     with pytest.raises(ValueError, match=r"Only .tbi or .csi indexes are supported."):
         partition_into_regions(vcf_path, index_path=bogus_index_path, num_parts=2)

--- a/sgkit_vcf/tests/test_vcf_reader.py
+++ b/sgkit_vcf/tests/test_vcf_reader.py
@@ -109,8 +109,11 @@ def test_vcf_to_zarr__large_vcf(shared_datadir, is_path):
     assert ds["variant_id"].dtype == "O"
 
 
-def test_vcf_to_zarr__mutable_mapping(shared_datadir):
-    path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__mutable_mapping(shared_datadir, is_path):
+    path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
     output: MutableMapping[str, bytes] = {}
 
     vcf_to_zarr(path, output, chunk_length=5_000)

--- a/sgkit_vcf/tests/test_vcf_reader.py
+++ b/sgkit_vcf/tests/test_vcf_reader.py
@@ -6,10 +6,14 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 
 from sgkit_vcf import partition_into_regions, vcf_to_zarr
+from sgkit_vcf.tests.utils import path_for_test
 
 
-def test_vcf_to_zarr__small_vcf(shared_datadir):
-    path = shared_datadir / "sample.vcf.gz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__small_vcf(shared_datadir, is_path):
+    path = path_for_test(shared_datadir, "sample.vcf.gz", is_path)
     output = "vcf.zarr"
 
     vcf_to_zarr(path, output, chunk_length=5, chunk_width=2)
@@ -81,8 +85,11 @@ def test_vcf_to_zarr__small_vcf(shared_datadir):
     assert_array_equal(ds["call_genotype_phased"], call_genotype_phased)
 
 
-def test_vcf_to_zarr__large_vcf(shared_datadir):
-    path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__large_vcf(shared_datadir, is_path):
+    path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
     output = "vcf.zarr"
 
     vcf_to_zarr(path, output, chunk_length=5_000)
@@ -123,8 +130,11 @@ def test_vcf_to_zarr__mutable_mapping(shared_datadir):
     assert ds["variant_id"].dtype == "O"
 
 
-def test_vcf_to_zarr__parallel(shared_datadir):
-    path = shared_datadir / "CEUTrio.20.21.gatk3.4.g.vcf.bgz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__parallel(shared_datadir, is_path):
+    path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
     output = "vcf_concat.zarr"
     regions = ["20", "21"]
 
@@ -145,8 +155,15 @@ def test_vcf_to_zarr__parallel(shared_datadir):
     assert ds["variant_id"].dtype == "S1"
 
 
-def test_vcf_to_zarr__parallel_partitioned(shared_datadir):
-    path = shared_datadir / "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf.gz"
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__parallel_partitioned(shared_datadir, is_path):
+    path = path_for_test(
+        shared_datadir,
+        "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf.gz",
+        is_path,
+    )
     output = "vcf_concat.zarr"
 
     regions = partition_into_regions(path, num_parts=4)
@@ -158,10 +175,13 @@ def test_vcf_to_zarr__parallel_partitioned(shared_datadir):
     assert ds["variant_id"].shape == (1406,)
 
 
-def test_vcf_to_zarr__multiple(shared_datadir):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__multiple(shared_datadir, is_path):
     paths = [
-        shared_datadir / "CEUTrio.20.gatk3.4.g.vcf.bgz",
-        shared_datadir / "CEUTrio.21.gatk3.4.g.vcf.bgz",
+        path_for_test(shared_datadir, "CEUTrio.20.gatk3.4.g.vcf.bgz", is_path),
+        path_for_test(shared_datadir, "CEUTrio.21.gatk3.4.g.vcf.bgz", is_path),
     ]
     output = "vcf_concat.zarr"
 
@@ -181,10 +201,13 @@ def test_vcf_to_zarr__multiple(shared_datadir):
     assert ds.chunks["variants"] == (5000, 5000, 5000, 4910)
 
 
-def test_vcf_to_zarr__multiple_partitioned(shared_datadir):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__multiple_partitioned(shared_datadir, is_path):
     paths = [
-        shared_datadir / "CEUTrio.20.gatk3.4.g.vcf.bgz",
-        shared_datadir / "CEUTrio.21.gatk3.4.g.vcf.bgz",
+        path_for_test(shared_datadir, "CEUTrio.20.gatk3.4.g.vcf.bgz", is_path),
+        path_for_test(shared_datadir, "CEUTrio.21.gatk3.4.g.vcf.bgz", is_path),
     ]
     output = "vcf_concat.zarr"
 
@@ -206,10 +229,13 @@ def test_vcf_to_zarr__multiple_partitioned(shared_datadir):
     assert ds.chunks["variants"] == (5000, 5000, 5000, 4910)
 
 
-def test_vcf_to_zarr__mutiple_partitioned_invalid_regions(shared_datadir):
+@pytest.mark.parametrize(
+    "is_path", [True, False],
+)
+def test_vcf_to_zarr__mutiple_partitioned_invalid_regions(shared_datadir, is_path):
     paths = [
-        shared_datadir / "CEUTrio.20.gatk3.4.g.vcf.bgz",
-        shared_datadir / "CEUTrio.21.gatk3.4.g.vcf.bgz",
+        path_for_test(shared_datadir, "CEUTrio.20.gatk3.4.g.vcf.bgz", is_path),
+        path_for_test(shared_datadir, "CEUTrio.21.gatk3.4.g.vcf.bgz", is_path),
     ]
     output = "vcf_concat.zarr"
 

--- a/sgkit_vcf/tests/utils.py
+++ b/sgkit_vcf/tests/utils.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from sgkit.typing import PathType
+
+
+def path_for_test(shared_datadir: Path, file: str, is_path: bool = True) -> PathType:
+    """Return a test data path whose type is determined by `is_path`.
+
+    If `isPath` is True, return a `Path`, otherwise return a `str`.
+    """
+    path: PathType = shared_datadir / file
+    if not is_path:
+        path = str(path)
+    return path

--- a/sgkit_vcf/utils.py
+++ b/sgkit_vcf/utils.py
@@ -1,7 +1,5 @@
-import gzip
 import itertools
 import struct
-from pathlib import Path
 from typing import IO, Any, Dict, Iterator, Optional, Sequence, TypeVar
 
 import fsspec
@@ -32,18 +30,14 @@ def get_file_length(
     path: PathType, storage_options: Optional[Dict[str, str]] = None
 ) -> int:
     """Get the length of a file in bytes."""
-    if isinstance(path, Path):
-        return path.stat().st_size
-    else:
-        storage_options = storage_options or {}
-        with fsspec.open(path, **storage_options) as openfile:
-            fs = openfile.fs
-            size = fs.size(path)
-            if size is None:
-                raise IOError(
-                    f"Cannot determine size of file {path}"
-                )  # pragma: no cover
-            return int(size)
+    url = str(path)
+    storage_options = storage_options or {}
+    with fsspec.open(url, **storage_options) as openfile:
+        fs = openfile.fs
+        size = fs.size(url)
+        if size is None:
+            raise IOError(f"Cannot determine size of file {url}")  # pragma: no cover
+        return int(size)
 
 
 def get_file_offset(vfp: int) -> int:
@@ -96,10 +90,8 @@ def read_bytes_as_tuple(f: IO[Any], fmt: str) -> Sequence[Any]:
     return struct.Struct(fmt).unpack(data)
 
 
-def open_gzip(file: PathType, storage_options: Optional[Dict[str, str]]) -> IO[Any]:
-    if isinstance(file, Path):
-        return gzip.open(file)
-    else:
-        storage_options = storage_options or {}
-        openfile: IO[Any] = fsspec.open(file, compression="gzip", **storage_options)
-        return openfile
+def open_gzip(path: PathType, storage_options: Optional[Dict[str, str]]) -> IO[Any]:
+    url = str(path)
+    storage_options = storage_options or {}
+    openfile: IO[Any] = fsspec.open(url, compression="gzip", **storage_options)
+    return openfile

--- a/sgkit_vcf/utils.py
+++ b/sgkit_vcf/utils.py
@@ -36,11 +36,14 @@ def get_file_length(
         return path.stat().st_size
     else:
         storage_options = storage_options or {}
-        fs = fsspec.open(path, **storage_options).fs
-        size = fs.size(path)
-        if size is None:
-            raise IOError(f"Cannot determine size of file {path}")  # pragma: no cover
-        return int(size)
+        with fsspec.open(path, **storage_options) as openfile:
+            fs = openfile.fs
+            size = fs.size(path)
+            if size is None:
+                raise IOError(
+                    f"Cannot determine size of file {path}"
+                )  # pragma: no cover
+            return int(size)
 
 
 def get_file_offset(vfp: int) -> int:

--- a/sgkit_vcf/vcf_partition.py
+++ b/sgkit_vcf/vcf_partition.py
@@ -1,12 +1,13 @@
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
+import fsspec
 import numpy as np
 from cyvcf2 import VCF
 
 from sgkit.typing import PathType
-from sgkit_vcf.csi import read_csi
-from sgkit_vcf.tbi import read_tabix
+from sgkit_vcf.csi import CSI_EXTENSION, read_csi
+from sgkit_vcf.tbi import TABIX_EXTENSION, read_tabix
 from sgkit_vcf.utils import ceildiv, get_file_length
 
 
@@ -17,32 +18,64 @@ def region_string(contig: str, start: int, end: Optional[int] = None) -> str:
         return f"{contig}:{start}-"
 
 
-def get_tabix_path(vcf_path: PathType) -> Optional[Path]:
-    tbi_path = Path(vcf_path).parent / (Path(vcf_path).name + ".tbi")
-    if tbi_path.exists():
-        return tbi_path
+def get_tabix_path(
+    vcf_path: PathType, storage_options: Optional[Dict[str, str]] = None
+) -> Optional[PathType]:
+    if isinstance(vcf_path, Path):
+        tbi_path = Path(vcf_path).parent / (Path(vcf_path).name + TABIX_EXTENSION)
+        if tbi_path.exists():
+            return tbi_path
+        else:
+            return None
     else:
-        return None
+        storage_options = storage_options or {}
+        tbi_path = vcf_path + TABIX_EXTENSION
+        fs = fsspec.open(vcf_path, **storage_options).fs
+        if fs.exists(tbi_path):
+            return tbi_path
+        else:
+            return None
 
 
-def get_csi_path(vcf_path: PathType) -> Optional[Path]:
-    csi_path = Path(vcf_path).parent / (Path(vcf_path).name + ".csi")
-    if csi_path.exists():
-        return csi_path
+def get_csi_path(
+    vcf_path: PathType, storage_options: Optional[Dict[str, str]] = None
+) -> Optional[PathType]:
+    if isinstance(vcf_path, Path):
+        csi_path = Path(vcf_path).parent / (Path(vcf_path).name + CSI_EXTENSION)
+        if csi_path.exists():
+            return csi_path
+        else:
+            return None
     else:
-        return None
+        storage_options = storage_options or {}
+        csi_path = vcf_path + CSI_EXTENSION
+        fs = fsspec.open(vcf_path, **storage_options).fs
+        if fs.exists(csi_path):
+            return csi_path
+        else:
+            return None
 
 
-def read_index(index_path: Path) -> Any:
-    if index_path.suffix == ".tbi":
-        return read_tabix(index_path)
-    elif index_path.suffix == ".csi":
-        return read_csi(index_path)
+def read_index(
+    index_path: PathType, storage_options: Optional[Dict[str, str]] = None
+) -> Any:
+    if isinstance(index_path, Path):
+        if index_path.suffix == TABIX_EXTENSION:
+            return read_tabix(index_path, storage_options=storage_options)
+        elif index_path.suffix == CSI_EXTENSION:
+            return read_csi(index_path, storage_options=storage_options)
+        else:
+            raise ValueError("Only .tbi or .csi indexes are supported.")
     else:
-        raise ValueError("Only .tbi or .csi indexes are supported.")
+        if index_path.endswith(TABIX_EXTENSION):
+            return read_tabix(index_path, storage_options=storage_options)
+        elif index_path.endswith(CSI_EXTENSION):
+            return read_csi(index_path, storage_options=storage_options)
+        else:
+            raise ValueError("Only .tbi or .csi indexes are supported.")
 
 
-def get_sequence_names(vcf_path: Path, index: Any) -> Any:
+def get_sequence_names(vcf_path: PathType, index: Any) -> Any:
     try:
         # tbi stores sequence names
         return index.sequence_names
@@ -57,6 +90,7 @@ def partition_into_regions(
     index_path: Optional[PathType] = None,
     num_parts: Optional[int] = None,
     target_part_size: Optional[int] = None,
+    storage_options: Optional[Dict[str, str]] = None,
 ) -> Optional[Sequence[str]]:
     """
     Calculate genomic region strings to partition a compressed VCF or BCF file into roughly equal parts.
@@ -82,6 +116,8 @@ def partition_into_regions(
         The desired number of parts to partition the VCF file into, by default None
     target_part_size : Optional[int], optional
         The desired size, in bytes, of each (compressed) part of the partitioned VCF, by default None
+    storage_options: Optional[Dict[str, str]], optional
+        Any additional parameters for the storage backend (see `fsspec.open`).
 
     Returns
     -------
@@ -111,14 +147,14 @@ def partition_into_regions(
         raise ValueError("target_part_size must be positive")
 
     if index_path is None:
-        index_path = get_tabix_path(vcf_path)
+        index_path = get_tabix_path(vcf_path, storage_options=storage_options)
         if index_path is None:
-            index_path = get_csi_path(vcf_path)
+            index_path = get_csi_path(vcf_path, storage_options=storage_options)
             if index_path is None:
                 raise ValueError("Cannot find .tbi or .csi file.")
 
     # Calculate the desired part file boundaries
-    file_length = get_file_length(vcf_path)
+    file_length = get_file_length(vcf_path, storage_options=storage_options)
     if num_parts is not None:
         target_part_size = file_length // num_parts
     elif target_part_size is not None:
@@ -128,7 +164,7 @@ def partition_into_regions(
     part_lengths = np.array([i * target_part_size for i in range(num_parts)])  # type: ignore
 
     # Get the file offsets from .tbi/.csi
-    index = read_index(index_path)
+    index = read_index(index_path, storage_options=storage_options)
     sequence_names = get_sequence_names(vcf_path, index)
     file_offsets, region_contig_indexes, region_positions = index.offsets()
 

--- a/sgkit_vcf/vcf_partition.py
+++ b/sgkit_vcf/vcf_partition.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
 import fsspec
@@ -20,61 +19,42 @@ def region_string(contig: str, start: int, end: Optional[int] = None) -> str:
 
 def get_tabix_path(
     vcf_path: PathType, storage_options: Optional[Dict[str, str]] = None
-) -> Optional[PathType]:
-    if isinstance(vcf_path, Path):
-        tbi_path = Path(vcf_path).parent / (Path(vcf_path).name + TABIX_EXTENSION)
-        if tbi_path.exists():
+) -> Optional[str]:
+    url = str(vcf_path)
+    storage_options = storage_options or {}
+    tbi_path = url + TABIX_EXTENSION
+    with fsspec.open(url, **storage_options) as openfile:
+        fs = openfile.fs
+        if fs.exists(tbi_path):
             return tbi_path
         else:
             return None
-    else:
-        storage_options = storage_options or {}
-        tbi_path = vcf_path + TABIX_EXTENSION
-        with fsspec.open(vcf_path, **storage_options) as openfile:
-            fs = openfile.fs
-            if fs.exists(tbi_path):
-                return tbi_path
-            else:
-                return None
 
 
 def get_csi_path(
     vcf_path: PathType, storage_options: Optional[Dict[str, str]] = None
-) -> Optional[PathType]:
-    if isinstance(vcf_path, Path):
-        csi_path = Path(vcf_path).parent / (Path(vcf_path).name + CSI_EXTENSION)
-        if csi_path.exists():
+) -> Optional[str]:
+    url = str(vcf_path)
+    storage_options = storage_options or {}
+    csi_path = url + CSI_EXTENSION
+    with fsspec.open(url, **storage_options) as openfile:
+        fs = openfile.fs
+        if fs.exists(csi_path):
             return csi_path
         else:
             return None
-    else:
-        storage_options = storage_options or {}
-        csi_path = vcf_path + CSI_EXTENSION
-        with fsspec.open(vcf_path, **storage_options) as openfile:
-            fs = openfile.fs
-            if fs.exists(csi_path):
-                return csi_path
-            else:
-                return None
 
 
 def read_index(
     index_path: PathType, storage_options: Optional[Dict[str, str]] = None
 ) -> Any:
-    if isinstance(index_path, Path):
-        if index_path.suffix == TABIX_EXTENSION:
-            return read_tabix(index_path, storage_options=storage_options)
-        elif index_path.suffix == CSI_EXTENSION:
-            return read_csi(index_path, storage_options=storage_options)
-        else:
-            raise ValueError("Only .tbi or .csi indexes are supported.")
+    url = str(index_path)
+    if url.endswith(TABIX_EXTENSION):
+        return read_tabix(url, storage_options=storage_options)
+    elif url.endswith(CSI_EXTENSION):
+        return read_csi(url, storage_options=storage_options)
     else:
-        if index_path.endswith(TABIX_EXTENSION):
-            return read_tabix(index_path, storage_options=storage_options)
-        elif index_path.endswith(CSI_EXTENSION):
-            return read_csi(index_path, storage_options=storage_options)
-        else:
-            raise ValueError("Only .tbi or .csi indexes are supported.")
+        raise ValueError("Only .tbi or .csi indexes are supported.")
 
 
 def get_sequence_names(vcf_path: PathType, index: Any) -> Any:

--- a/sgkit_vcf/vcf_partition.py
+++ b/sgkit_vcf/vcf_partition.py
@@ -30,11 +30,12 @@ def get_tabix_path(
     else:
         storage_options = storage_options or {}
         tbi_path = vcf_path + TABIX_EXTENSION
-        fs = fsspec.open(vcf_path, **storage_options).fs
-        if fs.exists(tbi_path):
-            return tbi_path
-        else:
-            return None
+        with fsspec.open(vcf_path, **storage_options) as openfile:
+            fs = openfile.fs
+            if fs.exists(tbi_path):
+                return tbi_path
+            else:
+                return None
 
 
 def get_csi_path(
@@ -49,11 +50,12 @@ def get_csi_path(
     else:
         storage_options = storage_options or {}
         csi_path = vcf_path + CSI_EXTENSION
-        fs = fsspec.open(vcf_path, **storage_options).fs
-        if fs.exists(csi_path):
-            return csi_path
-        else:
-            return None
+        with fsspec.open(vcf_path, **storage_options) as openfile:
+            fs = openfile.fs
+            if fs.exists(csi_path):
+                return csi_path
+            else:
+                return None
 
 
 def read_index(


### PR DESCRIPTION
This change uses [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) for reading `.tbi` and `.csi` files.

The unit tests are now parameterized to use both a local filesystem fsspec implementation and a local `pathlib.Path`. In addition, I did a manual test where I uploaded the test data into a GCS bucket and successfully ran the unit tests against them, which involved reading the index files *and* the actual VCF files (via htslib).

Note that this means there are two code paths for cloud: `fsspec` for the index metadata operations when running `partition_into_regions`, and the cyvcf2/htslib path for reading variants. This will need to be documented clearly, since it will have implications for configuring authentication etc.

Keyword args can be passed to `fsspec` via a `storage_options` dictionary, like in [Dask](https://docs.dask.org/en/latest/dataframe-create.html?highlight=storage_options#reading-from-various-locations).

Fixes #5 